### PR TITLE
Fix auto-merge: switch to pascalgn/automerge-action

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,8 +3,8 @@ name: Auto-merge Dependabot PRs
 on:
   pull_request:
     types:
-      - opened
       - labeled
+      - opened
       - synchronize
 
 jobs:
@@ -12,7 +12,11 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          merge-method: squash
+      - uses: actions/checkout@v4
+
+      - name: Automerge PR
+        uses: pascalgn/automerge-action@v0.15.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_METHOD: squash
+          MERGE_LABELS: ""


### PR DESCRIPTION
- Replaces broken gh-based approach
- Now uses a reliable GitHub Actions method that merges PRs after CI
- Works with dependabot[bot] and squash merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow for auto-merging Dependabot pull requests to improve reliability and maintain squash merge method. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->