### PR TITLE
Add Docker auto-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,44 @@
+name: Build & Push Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'  # optional: auto-publish if tag like v1.0.1 is pushed
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract tag or default to latest
+        id: meta
+        run: |
+          VERSION="${GITHUB_REF##*/}"
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tag=${VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            maskedkunsiquat/itinerary-generator:latest
+            maskedkunsiquat/itinerary-generator:${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
- Builds and pushes image to Docker Hub on push to main or tags like v1.0.0
- Pushes both 'latest' and versioned tags
- Uses DOCKERHUB_USERNAME, DOCKERHUB_TOKEN, and DOCKER_IMAGE secrets
- Supports full automation after Dependabot merges