### PR TITLE
changing the `Dockerfile` base image:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Phase 2: Web UI
-FROM python:3.13-slim
+FROM python:alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
- Minor runtime version update
- Image is smaller by 26 MB
- Image contains 101 fewer packages
- Tag is preferred tag
- Image introduces no new vulnerability but removes 26
- alpine is more popular with 41K pulls per month

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the base Docker image to use Alpine Linux, resulting in a smaller container size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->