### PR TITLE
Fix Alpine image build: replace apt with apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 # Dockerfile for Phase 2: Web UI
 FROM python:alpine
 
+# Create app directory
 WORKDIR /app
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    curl \
+    build-base \
+    libffi-dev \
+    tzdata \
+    ca-certificates
 
 # Copy all project files
 COPY . /app


### PR DESCRIPTION
- Replaces Debian-style apt-get with Alpine's apk add
- Installs curl, build-base, tzdata, libffi-dev, ca-certificates
- Unblocks docker-publish workflow for python:alpine base image