### PR TITLE
ci: ensure latest and version tags point to same image digest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     tags:
-      - 'v*'  # optional: auto-publish if tag like v1.0.1 is pushed
+      - 'v*.*.*'
 
 jobs:
   docker:
@@ -33,14 +33,14 @@ jobs:
         with:
           images: maskedkunsiquat/itinerary-generator
 
-      - name: Extract tag or default to latest
+      - name: Determine tags
         id: version
         run: |
-          VERSION="${GITHUB_REF##*/}"
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "tag=${VERSION}" >> $GITHUB_OUTPUT
+            VERSION="${GITHUB_REF##*/}"
+            echo "tags=maskedkunsiquat/itinerary-generator:${VERSION},maskedkunsiquat/itinerary-generator:latest" >> $GITHUB_OUTPUT
           else
-            echo "tag=latest" >> $GITHUB_OUTPUT
+            echo "tags=maskedkunsiquat/itinerary-generator:latest" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push image (with SBOM and provenance)
@@ -50,7 +50,5 @@ jobs:
           push: true
           sbom: true
           provenance: mode=max
-          tags: |
-            maskedkunsiquat/itinerary-generator:latest
-            maskedkunsiquat/itinerary-generator:${{ steps.version.outputs.tag }}
+          tags: ${{ steps.version.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- Refines tag logic to avoid digest drift on Docker Hub
- Pushes both `latest` and `vX.Y.Z` tags only on versioned tag pushes
- Pushes only `latest` on main branch updates
- Keeps SBOM and provenance generation intact for supply chain compliance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Docker image publishing workflow to improve tag handling and ensure images are tagged with both the semantic version and "latest" when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->