### PR TITLE
ci(docker): limit image builds to relevant file changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,9 +2,17 @@ name: Build & Push Docker Image
 
 on:
   push:
-    branches: [main]
     tags:
       - 'v*.*.*'
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - 'docker-compose.yaml'
+      - 'app.py'
+      - 'generate_itinerary.py'
+      - 'requirements*.txt'
+      - '.github/workflows/docker.yml'
 
 jobs:
   docker:


### PR DESCRIPTION
- Workflow now only triggers on Docker-related file updates (Dockerfile, app.py, requirements, etc.)
- Prevents unnecessary image builds from README or test changes
- Tag pushes (vX.Y.Z) still trigger full build and publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow triggers to only run Docker image builds when relevant files are changed, reducing unnecessary workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->