### PR TITLE
ci(codecov): add test result analytics via JUnit + Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,26 +13,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
 
-    - name: Run tests with coverage
-      run: |
-        pytest --cov=. --cov-branch --cov-report=term --cov-report=xml
+      - name: Run tests with coverage and JUnit output
+        run: |
+          pytest --cov=. --cov-branch \
+                 --cov-report=term \
+                 --cov-report=xml \
+                 --junitxml=junit.xml -o junit_family=legacy
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}  # Optional for public repos
-        files: ./coverage.xml
-        verbose: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}  # optional for public repos
+          files: ./coverage.xml
+          verbose: true
+
+      - name: Upload test results to Codecov (JUnit)
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Adds pytest output as JUnit XML for flake/timing insights
- Uploads both coverage and test results to Codecov dashboard
- Uses codecov/test-results-action@v1 for JUnit upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced test reporting by generating JUnit XML reports during test runs.
  - Added automatic upload of JUnit test results to Codecov for improved visibility.
  - Reformatted workflow steps for consistency and updated step descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->